### PR TITLE
Tweaked colorisation precedence for built-in symbols

### DIFF
--- a/Mathematica.tmbundle/Syntaxes/Mathematica.JSON-tmLanguage
+++ b/Mathematica.tmbundle/Syntaxes/Mathematica.JSON-tmLanguage
@@ -13,9 +13,6 @@
             "include": "#top_level_definition"
         }, 
         {
-            "include": "#builtin_symbols"
-        }, 
-        {
             "include": "#gu_symbols"
         }, 
         {
@@ -29,6 +26,9 @@
         }, 
         {
             "include": "#line_declarations"
+        }, 
+        {
+            "include": "#builtin_symbols"
         }, 
         {
             "include": "#builtin_operators"

--- a/Mathematica.tmbundle/Syntaxes/Mathematica.tmLanguage
+++ b/Mathematica.tmbundle/Syntaxes/Mathematica.tmLanguage
@@ -35,10 +35,6 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#builtin_symbols</string>
-		</dict>
-		<dict>
-			<key>include</key>
 			<string>#gu_symbols</string>
 		</dict>
 		<dict>
@@ -56,6 +52,10 @@
 		<dict>
 			<key>include</key>
 			<string>#line_declarations</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#builtin_symbols</string>
 		</dict>
 		<dict>
 			<key>include</key>


### PR DESCRIPTION
The current colorisation precedence is preventing some rules to fire.

Before

<img width="1680" alt="screen shot 2018-04-20 at 10 00 21" src="https://user-images.githubusercontent.com/10938229/39038884-c92601fc-4484-11e8-94a9-43c2516ebb22.png">

After

<img width="1680" alt="screen shot 2018-04-20 at 10 00 06" src="https://user-images.githubusercontent.com/10938229/39038899-cf6785fe-4484-11e8-8341-bda2d28d671f.png">
